### PR TITLE
pipenv install failed due with permissions error

### DIFF
--- a/install_raspilot.sh
+++ b/install_raspilot.sh
@@ -68,6 +68,7 @@ sudo make
 sudo checkinstall
 
 git clone https://github.com/gernby/raspberry-pilot.git raspilot
+sudo chown -R "{$USER}:{$USER}" ~/.local
 pip3 install pipenv --user
 
 # Exit SSH and log in again, since pipenv won't work without it


### PR DESCRIPTION
.local was owned by root.root and left me with read only permissions. that caused

pip3 install pipenv --user

to fail. Couldn't write to ~/.local. This also failed somewhere else, so I may have to move the chown command up.

Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
