### PR TITLE
missing -y on the final apt install

### DIFF
--- a/install_raspilot.sh
+++ b/install_raspilot.sh
@@ -93,7 +93,7 @@ crontab -l
 sudo cp ~/raspilot/phonelibs/usercfg.txt /boot/firmware/usercfg.txt
 sudo cp ~/raspilot/phonelibs/influxdb.conf /etc/influxdb/influxdb.conf
 
-sudo apt --fix-broken install
+sudo apt --fix-broken install -y
 sudo apt clean -y
 sudo bash phonelibs/install_capnp.sh
 


### PR DESCRIPTION
The install script was missing a -y on an apt install, causing it to stop and wait for a confirmation

Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
