### PR TITLE
more notes for prepping the image - how long to wait before installing wifi support

### DIFF
--- a/start_install.sh
+++ b/start_install.sh
@@ -23,6 +23,11 @@
 # run ifconfig to get the Pi IP address
 # SSH into RPi
 # ssh ubuntu@<ip address>
+# top
+# Press <i> to reduce the number of active processes shown
+# Device will automatically update
+# Wait for "up" in the top left corner to reach 10 minutes
+# (Note: you cannot proceed with installing wifi support until the auto update completes)
 #
 # connect to Wifi
 # sudo apt install network-manager


### PR DESCRIPTION
Additional detail about setting up the environment. You must wait until any automatic updates after the first boot and before adding WiFi support.

Choose one of the templates below:

# Fingerprint
This pull requests adds a fingerprint for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...

# Car support
This pull requests adds support for <Make - Model - Year - Trim>.

This is an explorer link to a drive with the stock system enabled: ...
This is an explorer link to a drive with openpilot system enabled: ...

# Feature
This pull requests adds feature X

## Description
Explain what the feature does

## Testing
Explain how the feature was tested. Either by the added unit tests, or what tests were performed while driving.
