### PR TITLE
must sudo to connect to wifi

### DIFF
--- a/start_install.sh
+++ b/start_install.sh
@@ -28,7 +28,7 @@
 # sudo apt install network-manager
 # systemctl start NetworkManager
 # nmcli d wifi list
-# nmcli d wifi connect <WiFiSSID> password <WiFiPassword>
+# sudo nmcli d wifi connect <WiFiSSID> password <WiFiPassword>
 # 
 # monitor CPU temperature
 # cat /sys/class/thermal/thermal_zone0/temp


### PR DESCRIPTION
Update the installation notes to reflect the fact that the user must use sudo when using nmcli to connect to WiFi. You can use nmcli to list the available WiFi networks but you must use sudo to connect.