### PR TITLE
can't nice to a negative priority without sudo

### DIFF
--- a/controls.sh
+++ b/controls.sh
@@ -15,4 +15,4 @@ pkill -f dashboard
 #nice -10 python ~/raspilot/dashboard.py 1 &
 #sleep 15
 pkill -f laterald
-nice -10 python ~/raspilot/selfdrive/controls/laterald.py &
+sudo nice -10 python ~/raspilot/selfdrive/controls/laterald.py &


### PR DESCRIPTION
In order to set a negative niceness, you must use sudo. that explains the error about failing to set the priority for laterald

chrt: failed to set pid 1863's policy: Operation not permitted

