### PR TITLE
laterald needs an sudo to set a negative nice

### DIFF
--- a/controls.sh
+++ b/controls.sh
@@ -15,4 +15,4 @@ pkill -f dashboard
 #nice -10 python ~/raspilot/dashboard.py 1 &
 #sleep 15
 pkill -f laterald
-nice -10 python ~/raspilot/selfdrive/controls/laterald.py &
+sudo nice -10 python ~/raspilot/selfdrive/controls/laterald.py &


### PR DESCRIPTION
this clears the permission error when `controls.sh` tries to run `laterald.py` with a negative `nice` value.