### PR TITLE
adding automatic drive upload functionality if panda is disconnected

### DIFF
--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -59,7 +59,7 @@ class kegman_conf():
     self.element_updated = False
 
     if Reset or not os.path.isfile(os.path.expanduser('~/kegman.json')):
-      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1"}
+      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1","autoUpload":"0"}
       self.element_updated = True
     else:
       with open(os.path.expanduser('~/kegman.json'), 'r') as f:

--- a/selfdrive/pandad.py
+++ b/selfdrive/pandad.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # simple boardd wrapper that updates the panda first
 import os
+import subprocess
 import time
 from selfdrive.kegman_conf import kegman_conf
 
@@ -87,6 +88,15 @@ def update_panda():
       print("Version mismatch after flashing, exiting")
       raise AssertionError
 
+def upload_drives():
+  print("Attempting connection to panda")
+
+  panda = None
+  panda_list = Panda.list()
+  if len(panda_list) == 0: 
+    print("Panda disconnected, safe to upload")
+    subprocess.call(['python3', 'upload_files.py'])
+
 
 def main(gctx=None):
   setproctitle('pandad')
@@ -94,8 +104,11 @@ def main(gctx=None):
     kegman = kegman_conf()  #.read_config()
     if bool(int(kegman.conf['useAutoFlash'])): 
       update_panda()
+    if bool(int(kegman.conf['autoUpload'])): 
+      upload_drives()
   except:
     pass
+
   #update_panda()
   os.chdir("selfdrive/boardd")
   os.execvp("./boardd", ["./boardd"])


### PR DESCRIPTION
# Feature
This pull requests adds an auto upload of drives feature if the panda is disconnected

## Description
If the panda is disconnected then the RP will attempt to upload drives to Gernby. It requires changing "autoUpload" in the kegman.json from "0" to "1".

## Testing
Tested the functionality with panda connected and disconnected, as well as setting the autoUpload parameter to 1 and 0.
