### PR TITLE
Add BP/V support for increased torque cars

### DIFF
--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -165,10 +165,10 @@ class CarController():
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
     
-    if int(self.kegman.conf['BP1']) > 0:
-      steer_lookup_bp = [-1 * int(self.kegman.conf['BP2']) , -1 * int(self.kegman.conf['BP1']) , 0 , int(self.kegman.conf['BP1']) , int(self.kegman.conf['BP2']) ]
-      steer_lookup_v  = [-1 * int(self.kegman.conf['V2']) , -1 * int(self.kegman.conf['V1']) , 0 , int(self.kegman.conf['V1']) , int(self.kegman.conf['V2']) ]
-      apply_steer = int(interp(-actuators.steer * int(self.kegman.conf['V2']), steer_lookup_bp, steer_lookup_v))
+    if int(kegman.conf['BP1']) > 0:
+      steer_lookup_bp = [-1 * int(kegman.conf['BP2']) , -1 * int(kegman.conf['BP1']) , 0 , int(kegman.conf['BP1']) , int(kegman.conf['BP2']) ]
+      steer_lookup_v  = [-1 * int(kegman.conf['V2']) , -1 * int(kegman.conf['V1']) , 0 , int(kegman.conf['V1']) , int(kegman.conf['V2']) ]
+      apply_steer = int(interp(-actuators.steer * int(kegman.conf['V2']), steer_lookup_bp, steer_lookup_v))
     else:
       apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -164,7 +164,13 @@ class CarController():
     # steer torque is converted back to CAN reference (positive when steering right)
     apply_gas = clip(actuators.gas, 0., 1.)
     apply_brake = int(clip(self.brake_last * BRAKE_MAX, 0, BRAKE_MAX - 1))
-    apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
+    
+    if int(self.kegman.conf['BP1']) > 0:
+      steer_lookup_bp = [-1 * int(self.kegman.conf['BP2']) , -1 * int(self.kegman.conf['BP1']) , 0 , int(self.kegman.conf['BP1']) , int(self.kegman.conf['BP2']) ]
+      steer_lookup_v  = [-1 * int(self.kegman.conf['V2']) , -1 * int(self.kegman.conf['V1']) , 0 , int(self.kegman.conf['V1']) , int(self.kegman.conf['V2']) ]
+      apply_steer = int(interp(-actuators.steer * int(self.kegman.conf['V2']), steer_lookup_bp, steer_lookup_v))
+    else:
+      apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 
     lkas_active = not CS.steer_not_allowed and CS.lkMode
 

--- a/selfdrive/car/honda/carcontroller.py
+++ b/selfdrive/car/honda/carcontroller.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from common.realtime import DT_CTRL
 from selfdrive.controls.lib.drive_helpers import rate_limit
-from common.numpy_fast import clip
+from common.numpy_fast import clip, interp
 from selfdrive.car import create_gas_command
 from selfdrive.car.honda import hondacan
 from selfdrive.car.honda.values import AH, CruiseButtons, CAR
@@ -168,7 +168,7 @@ class CarController():
     if int(kegman.conf['BP1']) > 0:
       steer_lookup_bp = [-1 * int(kegman.conf['BP2']) , -1 * int(kegman.conf['BP1']) , 0 , int(kegman.conf['BP1']) , int(kegman.conf['BP2']) ]
       steer_lookup_v  = [-1 * int(kegman.conf['V2']) , -1 * int(kegman.conf['V1']) , 0 , int(kegman.conf['V1']) , int(kegman.conf['V2']) ]
-      apply_steer = int(interp(-actuators.steer * int(kegman.conf['V2']), steer_lookup_bp, steer_lookup_v))
+      apply_steer = int(interp(-actuators.steer * int(kegman.conf['BP2']), steer_lookup_bp, steer_lookup_v))
     else:
       apply_steer = int(clip(-actuators.steer * STEER_MAX, -STEER_MAX, STEER_MAX))
 

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -59,8 +59,7 @@ class kegman_conf():
     self.element_updated = False
 
     if Reset or not os.path.isfile(os.path.expanduser('~/kegman.json')):
-      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1"}
-      self.element_updated = True
+      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1","BP1":"0","BP2":"0","V1":"0","V2":"0"}      self.element_updated = True
     else:
       with open(os.path.expanduser('~/kegman.json'), 'r') as f:
         self.config = json.load(f)

--- a/selfdrive/kegman_conf.py
+++ b/selfdrive/kegman_conf.py
@@ -59,7 +59,8 @@ class kegman_conf():
     self.element_updated = False
 
     if Reset or not os.path.isfile(os.path.expanduser('~/kegman.json')):
-      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1","BP1":"0","BP2":"0","V1":"0","V2":"0"}      self.element_updated = True
+      self.config = {"Kp":"-1","Ki":"-1","Kf":"-1","rateFFGain":"-1","reactMPC":"-1","dampMPC":"-1","useAutoFlash": "0","useInfluxDB":"0","requireBlinker":"1","requireNudge":"1","BP1":"0","BP2":"0","V1":"0","V2":"0"}
+      self.element_updated = True
     else:
       with open(os.path.expanduser('~/kegman.json'), 'r') as f:
         self.config = json.load(f)


### PR DESCRIPTION
This hasn't been tested yet. When BP/V is 0 the default logic is used. Otherwise it interpolates the break points to CAN values.