### PR TITLE
fixed apt_pkg no found error

### DIFF
--- a/start_install_tf.sh
+++ b/start_install_tf.sh
@@ -110,7 +110,7 @@ sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 3
 
 # fix apt_pkg missing error due to python3 breaking it :)
-sudo cp /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-aarch64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+sudo cp /usr/lib/python3/dist-packages/apt_pkg.cpython-*-aarch64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
 
 # start grafana and influxdb (installed but temporarily disabled to reduce resource usage)
 sudo /bin/systemctl daemon-reload

--- a/start_install_tf.sh
+++ b/start_install_tf.sh
@@ -109,6 +109,9 @@ sudo update-alternatives --install /usr/bin/python python /usr/bin/python2.7 1
 sudo update-alternatives --install /usr/bin/python python /usr/bin/python3.7 2
 sudo update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.7 3
 
+# fix apt_pkg missing error due to python3 breaking it :)
+sudo cp /usr/lib/python3/dist-packages/apt_pkg.cpython-36m-aarch64-linux-gnu.so /usr/lib/python3/dist-packages/apt_pkg.so
+
 # start grafana and influxdb (installed but temporarily disabled to reduce resource usage)
 sudo /bin/systemctl daemon-reload
 # sudo /bin/systemctl enable grafana-server


### PR DESCRIPTION
# Bug fix
This PR is to fix the "ModuleNotFoundError: No module named 'apt_pkg' when sudo apt-get update" introduced from changing the default python installations.

## Testing
Tested with fresh git clone of repo and running start_install_tf.sh script.
