### PR TITLE
chore : use --no-cache-dir flag to pip in dockerfiles to save space

### DIFF
--- a/panda/Dockerfile
+++ b/panda/Dockerfile
@@ -58,10 +58,10 @@ RUN pyenv install 2.7.12
 RUN pyenv global 3.7.3
 RUN pyenv rehash
 
-RUN pip install --upgrade pip==18.0
+RUN pip install --no-cache-dir --upgrade pip==18.0
 
 COPY requirements.txt /tmp/
-RUN pip install -r /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 RUN mkdir -p /home/batman
 ENV HOME /home/batman

--- a/panda/tests/build/Dockerfile
+++ b/panda/tests/build/Dockerfile
@@ -15,7 +15,7 @@ RUN pyenv install 3.7.3
 RUN pyenv global 3.7.3
 RUN pyenv rehash
 
-RUN pip install pycrypto==2.6.1
+RUN pip install --no-cache-dir pycrypto==2.6.1
 
 # Build esp toolchain
 RUN mkdir -p /panda/boardesp

--- a/panda/tests/misra/Dockerfile
+++ b/panda/tests/misra/Dockerfile
@@ -2,5 +2,5 @@ FROM ubuntu:16.04
 
 RUN apt-get update && apt-get install -y make python python-pip git
 COPY tests/safety/requirements.txt /panda/tests/safety/requirements.txt
-RUN pip install -r /panda/tests/safety/requirements.txt
+RUN pip install --no-cache-dir -r /panda/tests/safety/requirements.txt
 COPY . /panda

--- a/panda/tests/safety/Dockerfile
+++ b/panda/tests/safety/Dockerfile
@@ -15,5 +15,5 @@ RUN pyenv global 3.7.3
 RUN pyenv rehash
 
 COPY tests/safety/requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY . /panda

--- a/panda/tests/safety_replay/Dockerfile
+++ b/panda/tests/safety_replay/Dockerfile
@@ -15,7 +15,7 @@ RUN pyenv global 3.7.3
 RUN pyenv rehash
 
 COPY tests/safety_replay/requirements.txt requirements.txt
-RUN pip install -r requirements.txt
+RUN pip install --no-cache-dir -r requirements.txt
 COPY tests/safety_replay/install_capnp.sh install_capnp.sh
 RUN ./install_capnp.sh
 


### PR DESCRIPTION
## Description

using --no-cache-dir flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>